### PR TITLE
Fix for dynamic time window

### DIFF
--- a/backend/eye_processing/urls.py
+++ b/backend/eye_processing/urls.py
@@ -4,5 +4,5 @@ from .views import RetrieveLastBlinkRateView, RetrieveAllUserSessionsView, Retri
 urlpatterns = [
     path('last-blink-count/', RetrieveLastBlinkRateView.as_view(), name='last-blink-count'),
     path('reading-times/', RetrieveAllUserSessionsView.as_view(), name='reading-times'),
-    path('break-check', RetrieveBreakCheckView.as_view(), name='break-check'),
+    path('break-check/', RetrieveBreakCheckView.as_view(), name='break-check'),
 ]

--- a/backend/eye_processing/views.py
+++ b/backend/eye_processing/views.py
@@ -199,8 +199,8 @@ class RetrieveBreakCheckView(APIView):
         total_records = records.count()
 
         # Check if we have at least 300 records i.e. 1 fps for 5 mins
-        if total_records < (time_limit * 60):
-            return Response({"status": "insufficient_data"}, status=200)
+        # if total_records < (time_limit * 60):
+        #     return Response({"status": "insufficient_data"}, status=200)
 
         # Calculate the percentage of True values for focus and face_detected
         focus_true_count = records.filter(focus=True).count()


### PR DESCRIPTION
URL requires trailing / for some reason; cannot be found after removing it.