### PR TITLE
Making some function calls async() with threads

### DIFF
--- a/backend/eye_processing/views.py
+++ b/backend/eye_processing/views.py
@@ -177,7 +177,6 @@ class RetrieveBreakCheckView(APIView):
     def get(self, request, *args, **kwargs):
 
         time_limit = float(request.query_params.get('time_limit', 1))  # Default to 1 minute
-        print(time_limit)
 
         # Filter by user to retrieve the latest session ID and video ID
         current_session_id = SimpleEyeMetrics.objects.filter(user=request.user).aggregate(Max('session_id'))['session_id__max']
@@ -198,9 +197,9 @@ class RetrieveBreakCheckView(APIView):
 
         total_records = records.count()
 
-        # Check if we have at least 300 records i.e. 1 fps for 5 mins
+        # Check if we have enough data to determine focus and face detection levels in time window
         if total_records < (time_limit * 60):
-            return Response({"status": "insufficient_data"}, status=200)
+            return Response({"status": f"insufficient_data, found {total_records} records, current time: {now()} ... latest frame: {SimpleEyeMetrics.objects.order_by('timestamp').last().timestamp}"}, status=200)
 
         # Calculate the percentage of True values for focus and face_detected
         focus_true_count = records.filter(focus=True).count()


### PR DESCRIPTION
Made some heavy functions async, using threads to run them. Need to test it on deployed website to see any benefits - none seen on local daphne server.

This is done because **significant delay** seen between sending and receiving frames. This was fixed initally with async Websockets, but the culprit now is the eye processing methods that were added later. When removing these functions and database queries, the delay is gone. 

As a result, the delay causes the reading break check to no longer work, as it is not receiving enough frames during the time window to check for a break.