### PR TITLE
Fixed adding WPM and reading mode to database

### DIFF
--- a/backend/eye_processing/video_stream/consumers.py
+++ b/backend/eye_processing/video_stream/consumers.py
@@ -212,6 +212,8 @@ class VideoFrameConsumer(AsyncWebsocketConsumer):
                 left_iris_velocity=left_iris_velocity,
                 right_iris_velocity=right_iris_velocity, 
                 movement_type=movement_type,
+                reading_mode=reading_mode,
+                wpm=wpm
             )
             await sync_to_async(eye_metrics.save, thread_sensitive=True)()
 


### PR DESCRIPTION
For some reason, WPM and reading speed at each frame were not saved to DB.